### PR TITLE
Bump `round-based-derive` version

### DIFF
--- a/round-based-derive/Cargo.toml
+++ b/round-based-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "round-based-derive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Proc-macro for deriving `round-based` traits"


### PR DESCRIPTION
Forgot to do that in the previous PR