### PR TITLE
fix: correct duplicate field in SharedState Debug impl

### DIFF
--- a/round-based/src/state_machine/shared_state.rs
+++ b/round-based/src/state_machine/shared_state.rs
@@ -116,7 +116,7 @@ impl<M> core::fmt::Debug for SharedState<M> {
             .field("incoming_msg_present", &self.incoming_msg.is_some())
             .field("outgoing_msg_present", &self.outgoing_msg.is_some())
             .field("wants_recv_msg", &self.wants_recv_msg)
-            .field("wants_recv_msg", &self.wants_recv_msg)
+            .field("wants_send_msg", &self.wants_send_msg)
             .field("yielded", &self.yielded)
             .finish()
     }


### PR DESCRIPTION
## Summary
Closes #23
### Befor fix
Debug impl was printing:
`.field("wants_recv_msg", &self.wants_recv_msg)`
`.field("wants_recv_msg", &self.wants_recv_msg)`
`.field("yielded", &self.yielded)`
This prints `wants_recv_msg` twice and skips `wants_send_msg`.
### Fix
Replace second `wants_recv_msg` with `wants_send_msg`.