### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '27 4 * * 2'
+  push:
+    branches: [ "cggmp24/m" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for easy access by consumers.
+          # Allows the repository to be included in the Scorecard monitoring list.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.30.7
+        with:
+          sarif_file: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,4 +69,4 @@ it following the procedure described in [SECURITY.md](./SECURITY.md).
 
 Feel free to reach out to us [in Discord] as well.
 
-[in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+[in Discord]: https://discord.com/invite/hyperledger

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Docs](https://docs.rs/round-based/badge.svg)](https://docs.rs/round-based)
 [![Crates io](https://img.shields.io/crates/v/round-based.svg)](https://crates.io/crates/round-based)
 [![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discordapp.com/channels/905194001349627914/1285268686147424388)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/LFDT-Lockness/round-based/badge)](https://scorecard.dev/viewer/?uri=github.com/LFDT-Lockness/round-based)
 
 An MPC framework that unifies and simplifies the way of developing and working with
 multiparty protocols (e.g. threshold signing, random beacons, etc.).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![License: MIT](https://img.shields.io/crates/l/round-based.svg)
 [![Docs](https://docs.rs/round-based/badge.svg)](https://docs.rs/round-based)
 [![Crates io](https://img.shields.io/crates/v/round-based.svg)](https://crates.io/crates/round-based)
-[![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discordapp.com/channels/905194001349627914/1285268686147424388)
+[![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discord.com/invite/hyperledger)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/LFDT-Lockness/round-based/badge)](https://scorecard.dev/viewer/?uri=github.com/LFDT-Lockness/round-based)
 
 An MPC framework that unifies and simplifies the way of developing and working with
@@ -107,4 +107,4 @@ and our well-documented API.
 * `runtime-tokio` enables tokio-specific implementation of async runtime
 
 ## Join us in Discord!
-Feel free to reach out to us [in Discord](https://discordapp.com/channels/905194001349627914/1285268686147424388)!
+Feel free to reach out to us [in Discord](https://discord.com/invite/hyperledger)!

--- a/round-based/src/lib.rs
+++ b/round-based/src/lib.rs
@@ -2,6 +2,7 @@
 //! [![Docs](https://docs.rs/round-based/badge.svg)](https://docs.rs/round-based)
 //! [![Crates io](https://img.shields.io/crates/v/round-based.svg)](https://crates.io/crates/round-based)
 //! [![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discordapp.com/channels/905194001349627914/1285268686147424388)
+//! [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/LFDT-Lockness/round-based/badge)](https://scorecard.dev/viewer/?uri=github.com/LFDT-Lockness/round-based)
 //!
 //! An MPC framework that unifies and simplifies the way of developing and working with
 //! multiparty protocols (e.g. threshold signing, random beacons, etc.).

--- a/round-based/src/lib.rs
+++ b/round-based/src/lib.rs
@@ -1,7 +1,7 @@
 //! ![License: MIT](https://img.shields.io/crates/l/round-based.svg)
 //! [![Docs](https://docs.rs/round-based/badge.svg)](https://docs.rs/round-based)
 //! [![Crates io](https://img.shields.io/crates/v/round-based.svg)](https://crates.io/crates/round-based)
-//! [![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discordapp.com/channels/905194001349627914/1285268686147424388)
+//! [![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)](https://discord.com/invite/hyperledger)
 //! [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/LFDT-Lockness/round-based/badge)](https://scorecard.dev/viewer/?uri=github.com/LFDT-Lockness/round-based)
 //!
 //! An MPC framework that unifies and simplifies the way of developing and working with
@@ -124,7 +124,7 @@
 //! * `runtime-tokio` enables [tokio]-specific implementation of [async runtime](mpc::party::runtime)
 //!
 //! ## Join us in Discord!
-//! Feel free to reach out to us [in Discord](https://discordapp.com/channels/905194001349627914/1285268686147424388)!
+//! Feel free to reach out to us [in Discord](https://discord.com/invite/hyperledger)!
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 #![warn(unused_crate_dependencies, missing_docs)]


### PR DESCRIPTION
Adds the OpenSSF Scorecard GitHub Action and a Scorecard badge to the README. Also refreshes the Discord link to the LFDT-wide invite (the previous channel link has been reported as unreachable).

The Scorecard workflow runs weekly (and on `branch_protection_rule` / pushes to the default branch) and uploads results to:
- the repository's Code Scanning dashboard (SARIF), and
- the public OpenSSF results API (so the repo gets a Scorecard badge at https://scorecard.dev/).

Refs:
- https://openssf.org/projects/scorecard/
- https://github.com/marketplace/actions/ossf-scorecard-action

All third-party actions are pinned by commit SHA.