### PR TITLE
feat: add is_reliable_broadcast helper to Outgoing struct

### DIFF
--- a/round-based/src/delivery.rs
+++ b/round-based/src/delivery.rs
@@ -146,6 +146,11 @@ impl<M> Outgoing<M> {
         self.recipient.is_broadcast()
     }
 
+    /// Checks whether it's a reliable broadcast message
+    pub fn is_reliable_broadcast(&self) -> bool {
+        self.recipient.is_reliable_broadcast()
+    }
+
     /// Checks whether it's p2p message
     pub fn is_p2p(&self) -> bool {
         self.recipient.is_p2p()


### PR DESCRIPTION
Replaces closed PR #49 

Solves the issue #48 

Sorry for the delay. I have renamed the method to is_reliable_broadcast and added the required DCO sign-off. Ready for another look!

This branch has the renamed method `is_reliable_broadcast` and a clean, signed-off commit history.